### PR TITLE
Improve typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import type {
 } from 'firestore-converter'
 ```
 
-Some of these types are just to make it convenient and easy to migrate existing data converter code you may have and avoid having to decide whether you should be importing them from the `firebase/firestore` package or `firebase-admin/firestore`:
+Some of these types are just to make it convenient and easy to migrate existing data converter code you may have and avoid having to decide whether you should be importing them from the `firebase/firestore` package or `firebase-admin/firestore`, others help with making your converter independent of each specific client-side or server-side SDK:
 
 - `FirestoreDataConverter`
 - `WithFieldValue`
@@ -101,7 +101,7 @@ export class PersonConverter implements FirestoreDataConverter<Person, DBPerson>
 }
 ```
 
-You don't _have_ to declare the DB Model though, you can just use the `DocumentData` type in it's place so you only need to define the in memory object model.
+You don't _have_ to declare the DB Model though, you can omit it which will cause it to use the `DocumentData` type in it's place so you only need to define the applications in memory object model.
 
 Likewise you may not want to use the `WithFieldValue<Model>` in the `toFirestore` method which is only required if you'll be making use of [`FieldValue`](https://firebase.google.com/docs/reference/js/v8/firebase.firestore.FieldValue) sentinel types, but require you to cast the model types as in the example above.
 
@@ -142,13 +142,13 @@ import { cert, initializeApp } from 'firebase-admin/app'
 import { SERVICE_ACCOUNT_FILE } from '$env/static/private'
 import { getFirestore } from 'firebase-admin/firestore'
 import { PersonConverter, type Person } from './person'
-import { converter } from 'firestore-converter/firebase.server'
+import { createConverter } from 'firestore-converter/firebase.server'
 
-export const app = initializeApp({ credential: cert(SERVICE_ACCOUNT_FILE) })
+const app = initializeApp({ credential: cert(SERVICE_ACCOUNT_FILE) })
 
-export const firestore = getFirestore(app)
+const firestore = getFirestore(app)
 
-const personConverter = new PersonConverter(converter)
+const personConverter = createConverter(PersonConverter)
 
 export async function getPeople() {
   const col = firestore.collection('people').withConverter(personConverter)
@@ -176,9 +176,9 @@ import {
 } from '$env/static/public'
 import { getFirestore, collection, doc, getDoc, setDoc, getDocs } from 'firebase/firestore'
 import { PersonConverter, type Person } from './person'
-import { converter } from 'firestore-converter/firebase'
+import { createConverter } from 'firestore-converter/firebase'
 
-export const app = initializeApp({
+const app = initializeApp({
   apiKey: PUBLIC_API_KEY,
   authDomain: PUBLIC_AUTH_DOMAIN,
   databaseURL: PUBLIC_DATABASE_URL,
@@ -189,9 +189,9 @@ export const app = initializeApp({
   measurementId: PUBLIC_MEASUREMENT_ID,
 })
 
-export const firestore = getFirestore(app)
+const firestore = getFirestore(app)
 
-const personConverter = new PersonConverter(converter)
+const personConverter = createConverter(PersonConverter)
 
 export async function getPeople() {
   const col = collection(firestore, 'people').withConverter(personConverter)
@@ -203,7 +203,7 @@ export async function getPeople() {
 
 ### Result
 
-We can now load and save data easily from both client and server, using a single definition of you data converter classes.
+We can now load and save data easily from both client and server, using a single shared definition of your data converter classes.
 
 ### Default Converters
 

--- a/README.md
+++ b/README.md
@@ -109,22 +109,29 @@ Likewise you may not want to use the `WithFieldValue<Model>` in the `toFirestore
 
 The `Converter` instance passed in to your Data Converter class provides the following methods all from the perspective of the Object Model. You'll typically be using the `from...` methods in the `toFirestore` method (**from** Object Model, to DB Model) and the `to...` methods in the `fromFirestore` method (**to** Object Model, from DB Model). Personally, I would have make the 'to' and 'from' being to and from the database formats, but the firebase SDKs already used this opposite naming so I've aligned with that to hopefully avoid confusion.
 
-| Method                                        | Description                                          |
-| --------------------------------------------- | ---------------------------------------------------- |
-| **fromBase64String**(value: string): Binary   | Store a Base64 encoded string as a binary field      |
-| **fromUint8Array**(value: Uint8Array): Binary | Store a typed `Uint8Array` as a binary field         |
-| **fromHexString**(value: string): Binary      | Store a hex encoded string as a binary field         |
-| **fromString**(value: string): Binary         | Store a unicode string as a binary field             |
-| **fromDate**(value: Date): Timestamp          | Store a JavaScript Date object as a Timestamp        |
-| **toBase64String**(value: Binary): string     | Convert a binary field to a Base64 encoded string    |
-| **toUInt8Array**(value: Binary): Uint8Array   | Convert a binary field to a typed `Uint8Array`       |
-| **toHexString**(value: Binary): string        | Convert a binary field to a hex encoded string       |
-| **toString**(value: Binary): string           | Convert from a binary field to a unicode string      |
-| **toDate**(value: Timestamp): Date            | Convert from a Timestamp to a JavaScript Date object |
+| Method                                          | Description                                          |
+| ----------------------------------------------- | ---------------------------------------------------- |
+| **fromBase64String**(value: string): Binary     | Store a Base64 encoded string as a binary field      |
+| **fromUint8Array**(value: Uint8Array): Binary   | Store a typed `Uint8Array` as a binary field         |
+| **fromHexString**(value: string): Binary        | Store a hex encoded string as a binary field         |
+| **fromString**(value: string): Binary           | Store a unicode string as a binary field             |
+| **fromDate**(value: Date): Timestamp            | Store a JavaScript Date object as a Timestamp        |
+| **toBase64String**(value: Binary): string       | Convert a binary field to a Base64 encoded string    |
+| **toUInt8Array**(value: Binary): Uint8Array     | Convert a binary field to a typed `Uint8Array`       |
+| **toHexString**(value: Binary): string          | Convert a binary field to a hex encoded string       |
+| **toString**(value: Binary): string             | Convert from a binary field to a unicode string      |
+| **toDate**(value: Timestamp): Date              | Convert from a Timestamp to a JavaScript Date object |
+| **isBinary**(value: any): boolean               | Tests whether a field is a Binary value              |
+| **isTimestamp**(value: any): boolean            | Tests whether a field is a Timestamp value           |
+| **arrayRemove**(...elements: any[]): FieldValue | Returns a sentinel value to remove array elements    |
+| **arrayUnion**(...elements: any[]): FieldValue  | Returns a sentinel value to union array elements     |
+| **delete**()                                    | Returns a sentinel value to delete a field           |
+| **increment**(n: number): FieldValue            | Returns a sentinel value to increment a field        |
+| **serverTimestamp**(): FieldValue               | Returns a sentinel value to set a server timestamp   |
 
 ### Firebase Clients
 
-The converter class we've defined can now be used from both the Server _and_ the Client SDK. This is done by importing the appropriate `converter` implementation in each and passing it to the `PersonConverter` constructor to create an instance. This will handle the different field type conversions required.
+The converter class we've defined can now be used from both the Server _and_ the Client SDK. This is done by importing the appropriate `createConverter` function from each and passing the `PersonConverter` constructor to it to create an instance. This will handle the different field type conversions required.
 
 #### firebase.server
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "firestore-converter",
 	"description": "Share Firestore Data Converters between Client and Server Firebase SDK",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"homepage": "https://captaincodeman.github.io/firestore-converter/",
 	"repository": {
 		"type": "git",
@@ -33,7 +33,7 @@
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
 		"preview": "vite preview",
-		"package": "svelte-kit sync && tsup && publint",
+		"package": "tsup && publint",
 		"prepublishOnly": "npm run package",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
@@ -50,19 +50,6 @@
 		"./firebase.server": {
 			"types": "./dist/firebase.server/index.d.ts",
 			"import": "./dist/firebase.server/index.js"
-		}
-	},
-	"typesVersions": {
-		"*": {
-			"*": [
-				"./dist/index.d.ts"
-			],
-			"firebase": [
-				"./dist/firebase/index.d.ts"
-			],
-			"firebase.server": [
-				"./dist/firebase.server/index.d.ts"
-			]
 		}
 	},
 	"files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ dependencies:
   firebase-admin:
     specifier: ^12.0.0
     version: 12.0.0
-  uint8array-extras:
-    specifier: ^1.0.0
-    version: 1.0.0
 
 devDependencies:
   '@sveltejs/adapter-auto':
@@ -46,6 +43,9 @@ devDependencies:
   typescript:
     specifier: ^5.3.3
     version: 5.3.3
+  uint8array-extras:
+    specifier: ^1.0.0
+    version: 1.0.0
   vite:
     specifier: ^5.0.10
     version: 5.0.10(@types/node@20.10.5)
@@ -3118,7 +3118,7 @@ packages:
   /uint8array-extras@1.0.0:
     resolution: {integrity: sha512-0ygPQc4lTR+uhyqsH2F+/Yt6SESIHsHXRFq17QG3bIxpPJDwls9OU0SVITVlBNmTb9E7pVHA6fjfdj51ns6s0A==}
     engines: {node: '>=18'}
-    dev: false
+    dev: true
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -53,16 +53,23 @@ export interface Converter {
   toDate(value: Timestamp): Date
   isBinary(value: any): boolean
   isTimestamp(value: any): boolean
+  arrayRemove(...elements: any[]): FieldValue
+  arrayUnion(...elements: any[]): FieldValue
+  delete(): FieldValue
+  increment(n: number): FieldValue
+  serverTimestamp(): FieldValue
 }
 
 type Primitive = string | number | boolean | undefined | null
+
+type FieldValue = any
 
 export type WithFieldValue<T> =
   | T
   | (T extends Primitive
     ? T
     : T extends {}
-    ? { [K in keyof T]: WithFieldValue<T[K]> | any }
+    ? { [K in keyof T]: WithFieldValue<T[K]> | FieldValue }
     : never)
 
 export interface FirestoreDataConverterConstructor<T, TDB extends DocumentData> {

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -55,6 +55,25 @@ export interface Converter {
   isTimestamp(value: any): boolean
 }
 
+type Primitive = string | number | boolean | undefined | null
+
+export type WithFieldValue<T> =
+  | T
+  | (T extends Primitive
+    ? T
+    : T extends {}
+    ? { [K in keyof T]: WithFieldValue<T[K]> | any }
+    : never)
+
+export interface FirestoreDataConverterConstructor<T, TDB extends DocumentData> {
+  new(convert: Converter): FirestoreDataConverter<T, TDB>
+}
+
+export interface FirestoreDataConverter<T, TDB extends DocumentData> {
+  toFirestore(modelObject: WithFieldValue<T>): WithFieldValue<TDB>
+  fromFirestore(snapshot: QueryDocumentSnapshot<DocumentData, DocumentData>): T
+}
+
 /**
  * Recursively converts Firestore data types in the given object to native
  * JavaScript types using the provided Converter.

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -60,10 +60,17 @@ export interface Converter {
   serverTimestamp(): FieldValue
 }
 
+/** Type alias for primitive JavaScript types that can be stored in Firestore. */
 type Primitive = string | number | boolean | undefined | null
 
+/** Type alias for Firestore sentinel values */
 type FieldValue = any
 
+/**
+ * Type alias for wrapping a type T in the Firestore `FieldValue` type.
+ * This allows specifying a type to be converted to a Firestore field
+ * value like Timestamp or Bytes.
+ */
 export type WithFieldValue<T> =
   | T
   | (T extends Primitive
@@ -72,10 +79,16 @@ export type WithFieldValue<T> =
     ? { [K in keyof T]: WithFieldValue<T[K]> | FieldValue }
     : never)
 
+/**
+ * Interface for a constructor function that creates a FirestoreDataConverter.
+ */
 export interface FirestoreDataConverterConstructor<T, TDB extends DocumentData> {
   new(convert: Converter): FirestoreDataConverter<T, TDB>
 }
 
+/**
+ * Interface for a FirestoreDataConverter.
+ */
 export interface FirestoreDataConverter<T, TDB extends DocumentData> {
   toFirestore(modelObject: WithFieldValue<T>): WithFieldValue<TDB>
   fromFirestore(snapshot: QueryDocumentSnapshot<DocumentData, DocumentData>): T

--- a/src/lib/firebase.server/index.ts
+++ b/src/lib/firebase.server/index.ts
@@ -4,6 +4,7 @@ import { uint8ArrayToHex, hexToUint8Array } from 'uint8array-extras'
 import { uint8ArrayToString, stringToUint8Array } from 'uint8array-extras'
 import { toUint8Array } from 'uint8array-extras'
 import type { FirestoreDataConverter, DocumentData, WithFieldValue, QueryDocumentSnapshot } from 'firebase-admin/firestore'
+import { FieldValue } from 'firebase-admin/firestore'
 import { DefaultConverterBase } from "../converter"
 import type { Converter, DefaultConverterOptions, FirestoreDataConverterConstructor } from "../converter"
 
@@ -46,6 +47,21 @@ const converter: Converter = {
   },
   isTimestamp(value: any): boolean {
     return value instanceof Timestamp
+  },
+  arrayRemove(...elements: any[]) {
+    return FieldValue.arrayRemove(elements)
+  },
+  arrayUnion(...elements: any[]) {
+    return FieldValue.arrayUnion(elements)
+  },
+  delete() {
+    return FieldValue.delete()
+  },
+  increment(n: number) {
+    return FieldValue.increment(n)
+  },
+  serverTimestamp() {
+    return FieldValue.serverTimestamp()
   }
 }
 

--- a/src/lib/firebase.server/index.ts
+++ b/src/lib/firebase.server/index.ts
@@ -5,12 +5,12 @@ import { uint8ArrayToString, stringToUint8Array } from 'uint8array-extras'
 import { toUint8Array } from 'uint8array-extras'
 import type { FirestoreDataConverter, DocumentData, WithFieldValue, QueryDocumentSnapshot } from 'firebase-admin/firestore'
 import { DefaultConverterBase } from "../converter"
-import type { Converter, DefaultConverterOptions } from "../converter"
+import type { Converter, DefaultConverterOptions, FirestoreDataConverterConstructor } from "../converter"
 
 /**
  * Defines a Converter implementation for use in node, using firebase-admin serverside SDK
  */
-export const converter: Converter = {
+const converter: Converter = {
   fromBase64String(value: string) {
     return base64ToUint8Array(value)
   },
@@ -47,6 +47,10 @@ export const converter: Converter = {
   isTimestamp(value: any): boolean {
     return value instanceof Timestamp
   }
+}
+
+export function createConverter<T, TDB extends DocumentData>(dataConverter: FirestoreDataConverterConstructor<T, TDB>): FirestoreDataConverter<T, TDB> {
+  return new dataConverter(converter)
 }
 
 /**

--- a/src/lib/firebase/index.ts
+++ b/src/lib/firebase/index.ts
@@ -2,6 +2,7 @@ import { Bytes, Timestamp } from 'firebase/firestore'
 import { uint8ArrayToHex, hexToUint8Array } from 'uint8array-extras'
 import { uint8ArrayToString, stringToUint8Array } from 'uint8array-extras'
 import type { FirestoreDataConverter, DocumentData, WithFieldValue, QueryDocumentSnapshot } from 'firebase/firestore'
+import { arrayRemove, arrayUnion, deleteField, increment, serverTimestamp } from 'firebase/firestore'
 import { DefaultConverterBase  } from "../converter"
 import type { Converter, DefaultConverterOptions, FirestoreDataConverterConstructor } from "../converter"
 
@@ -44,6 +45,21 @@ const converter: Converter = {
   },
   isTimestamp(value: any): boolean {
     return value instanceof Timestamp
+  },
+  arrayRemove(...elements: any[]) {
+    return arrayRemove(elements)
+  },
+  arrayUnion(...elements: any[]) {
+    return arrayUnion(elements)
+  },
+  delete() {
+    return deleteField()
+  },
+  increment(n: number) {
+    return increment(n)
+  },
+  serverTimestamp() {
+    return serverTimestamp()
   }
 }
 

--- a/src/lib/firebase/index.ts
+++ b/src/lib/firebase/index.ts
@@ -3,12 +3,12 @@ import { uint8ArrayToHex, hexToUint8Array } from 'uint8array-extras'
 import { uint8ArrayToString, stringToUint8Array } from 'uint8array-extras'
 import type { FirestoreDataConverter, DocumentData, WithFieldValue, QueryDocumentSnapshot } from 'firebase/firestore'
 import { DefaultConverterBase  } from "../converter"
-import type { Converter, DefaultConverterOptions } from "../converter"
+import type { Converter, DefaultConverterOptions, FirestoreDataConverterConstructor } from "../converter"
 
 /**
  * Defines a Converter implementation for use in the browser, using firebase clientside SDK
  */
-export const converter: Converter = {
+const converter: Converter = {
   fromBase64String(value: string) {
     return Bytes.fromBase64String(value)
   },
@@ -45,6 +45,10 @@ export const converter: Converter = {
   isTimestamp(value: any): boolean {
     return value instanceof Timestamp
   }
+}
+
+export function createConverter<T, TDB extends DocumentData>(dataConverter: FirestoreDataConverterConstructor<T, TDB>): FirestoreDataConverter<T, TDB> {
+  return new dataConverter(converter)
 }
 
 /**

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,1 @@
-export type { Binary, Timestamp, Converter, DocumentData, QueryDocumentSnapshot } from './converter'
-export type { FirestoreDataConverter, WithFieldValue } from 'firebase/firestore'
+export type { Binary, Timestamp, Converter, DocumentData, QueryDocumentSnapshot, FirestoreDataConverter, WithFieldValue } from './converter'

--- a/src/routes/firebase.server.ts
+++ b/src/routes/firebase.server.ts
@@ -2,13 +2,13 @@ import { cert, initializeApp } from 'firebase-admin/app'
 import { SERVICE_ACCOUNT_FILE } from '$env/static/private'
 import { getFirestore } from 'firebase-admin/firestore'
 import { PersonConverter, type Person } from './person'
-import { converter } from 'firestore-converter/firebase.server'
+import { createConverter } from 'firestore-converter/firebase.server'
 
 export const app = initializeApp({ credential: cert(SERVICE_ACCOUNT_FILE) })
 
 export const firestore = getFirestore(app)
 
-const personConverter = new PersonConverter(converter)
+const personConverter = createConverter(PersonConverter)
 
 export async function getPeople() {
   const col = firestore.collection('people').withConverter(personConverter)

--- a/src/routes/firebase.server.ts
+++ b/src/routes/firebase.server.ts
@@ -4,9 +4,10 @@ import { getFirestore } from 'firebase-admin/firestore'
 import { PersonConverter, type Person } from './person'
 import { createConverter } from 'firestore-converter/firebase.server'
 
-export const app = initializeApp({ credential: cert(SERVICE_ACCOUNT_FILE) })
+const app = initializeApp({ credential: cert(SERVICE_ACCOUNT_FILE) })
+const firestore = getFirestore(app)
 
-export const firestore = getFirestore(app)
+// examples of creating and using an instance of PersonConverter from the firebase client-side SDK
 
 const personConverter = createConverter(PersonConverter)
 

--- a/src/routes/firebase.ts
+++ b/src/routes/firebase.ts
@@ -11,7 +11,7 @@ import {
 } from '$env/static/public'
 import { getFirestore, collection, doc, getDoc, setDoc, getDocs } from 'firebase/firestore'
 import { PersonConverter, type Person } from './person'
-import { converter } from 'firestore-converter/firebase'
+import { createConverter } from 'firestore-converter/firebase'
 
 export const app = initializeApp({
   apiKey: PUBLIC_API_KEY,
@@ -26,7 +26,7 @@ export const app = initializeApp({
 
 export const firestore = getFirestore(app)
 
-const personConverter = new PersonConverter(converter)
+const personConverter = createConverter(PersonConverter)
 
 export async function getPeople() {
   const col = collection(firestore, 'people').withConverter(personConverter)

--- a/src/routes/firebase.ts
+++ b/src/routes/firebase.ts
@@ -13,7 +13,7 @@ import { getFirestore, collection, doc, getDoc, setDoc, getDocs } from 'firebase
 import { PersonConverter, type Person } from './person'
 import { createConverter } from 'firestore-converter/firebase'
 
-export const app = initializeApp({
+const app = initializeApp({
   apiKey: PUBLIC_API_KEY,
   authDomain: PUBLIC_AUTH_DOMAIN,
   databaseURL: PUBLIC_DATABASE_URL,
@@ -24,7 +24,9 @@ export const app = initializeApp({
   measurementId: PUBLIC_MEASUREMENT_ID,
 })
 
-export const firestore = getFirestore(app)
+const firestore = getFirestore(app)
+
+// examples of creating and using an instance of PersonConverter from the firebase client-side SDK
 
 const personConverter = createConverter(PersonConverter)
 

--- a/src/routes/person.ts
+++ b/src/routes/person.ts
@@ -1,5 +1,6 @@
 import type { FirestoreDataConverter, WithFieldValue, DocumentData, QueryDocumentSnapshot, Binary, Timestamp, Converter } from 'firestore-converter'
 
+/** Person interface represents a person object to the application */
 export interface Person {
   id: string
   name: string
@@ -7,12 +8,16 @@ export interface Person {
   photo: string
 }
 
+/** DBPerson interface represents a person object as stored in Firestore */
 export interface DBPerson {
   name: string
   dob: Timestamp
   photo: Binary
 }
 
+/**
+ * PersonConverter implements the FirestoreDataConverter interface to convert between the Person model and DBPerson database representation.
+ */
 export class PersonConverter implements FirestoreDataConverter<Person, DBPerson> {
   constructor(private readonly convert: Converter) {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
+		"moduleResolution": "Node"
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//


### PR DESCRIPTION
Closes #6 

This changes `FirestoreDataConverter` and `WithFieldValue` to be _library_ representations to mirror the Firebase SDK ones. Effectively, we create our own converter and then wrap it in the SDK provided converter. This avoids the issues with mis-matched types that resulted in one of the SDK's adding `FieldValue` types to the app model (whichever wasn't the one who's `FirestoreDataConverter` and `WithFieldValue` was exported by the lib).

To handle the `FieldValue` incompatibilities (c'mon Google, why can't you just make things consistent in your own libs? Same with the "equals" prop ve "equals()" function debacle, it's just shoddy and poor) I've added methods to the `Converter` to provide the appropriate version (depending on whether it's the `firebase` or `firebase-admin` package).

The `converter` instance now isn't imported to pass into an implemented data converter, instead a `createConverter` factory does the construction for you, with the class passed in (and this factory passes in the `converter`)

End result is the `.data()` method now returns the proper app type, without any rogue `FieldValue` types added, for both SDKs.